### PR TITLE
fixed for PHP 8.2: ${var} string interpolation deprecated

### DIFF
--- a/includes/Bootstrap.php
+++ b/includes/Bootstrap.php
@@ -85,7 +85,7 @@ class Bootstrap {
 
 		$classes = array();
 		foreach ( $base_classes as $key => $class ) {
-			$classes[ $key ] = apply_filters( "sptp_module_${key}_class", $class::get_class() );
+			$classes[ $key ] = apply_filters( "sptp_module_{$key}_class", $class::get_class() );
 		}
 
 		return $classes;
@@ -99,7 +99,7 @@ class Bootstrap {
 		$modules = array();
 
 		foreach ( $classes as $key => $class ) {
-			$module          = apply_filters( "sptp_module_${key}", new $class(), $this );
+			$module          = apply_filters( "sptp_module_{$key}", new $class(), $this );
 			$modules[ $key ] = $module;
 		}
 

--- a/includes/Module/Permalink.php
+++ b/includes/Module/Permalink.php
@@ -45,7 +45,7 @@ class Permalink extends Module {
 		$post_date = strtotime( $post->post_date );
 
 		$rewritecode    = array(
-			"%${post_type}_slug%",
+			"%{$post_type}_slug%",
 			'%post_id%',
 			'%year%',
 			'%monthnum%',

--- a/includes/Module/Rewrite.php
+++ b/includes/Module/Rewrite.php
@@ -80,9 +80,9 @@ class Rewrite extends Module {
 		if ( $struct = $this->option->get_structure( $post_type ) ) {
 
 			$post_type_slug = $this->option->get_front_struct( $post_type );
-			add_rewrite_tag( "%${post_type}_slug%", "(${post_type_slug})", "post_type=${post_type}&slug=" );
+			add_rewrite_tag( "%{$post_type}_slug%", "({$post_type_slug})", "post_type={$post_type}&slug=" );
 
-			$struct = str_replace( array( $post_type_slug, '%postname%' ), array( "%${post_type}_slug%", "%{$post_type}%" ), $struct );
+			$struct = str_replace( array( $post_type_slug, '%postname%' ), array( "%{$post_type}_slug%", "%{$post_type}%" ), $struct );
 
 			// $rewrite_args['walk_dirs'] = false;
 			add_permastruct( $post_type, $struct, $permastruct_args );


### PR DESCRIPTION
下記のPHP Deprecatedが発生する箇所を書き換えました。

```
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Bootstrap.php on line 88
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in/wp-content/plugins/simple-post-type-permalinks/includes/Bootstrap.php on line 102
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Module/Rewrite.php on line 83
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Module/Rewrite.php on line 83
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Module/Rewrite.php on line 83
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Module/Rewrite.php on line 85
[20-Nov-2024 04:13:03 UTC] PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /wp-content/plugins/simple-post-type-permalinks/includes/Module/Permalink.php on line 48
```
